### PR TITLE
Potential fix for code scanning alert no. 3: Call to alloca in a loop

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -2432,10 +2432,9 @@ static void ExecuteMSDPPair(descriptor_t *apDescriptor, const char *apVariable, 
 
                                 if (j >= VariableNameTable[i].Min) {
                                     free(apDescriptor->pProtocol->pVariables[i]->pValueString);
-
-                                free(pBuffer);
                                     apDescriptor->pProtocol->pVariables[i]->pValueString = AllocString(pBuffer);
                                 }
+                                free(pBuffer);
                             }
                         } else /* This variable only accepts numeric values */
                         {


### PR DESCRIPTION
Potential fix for [https://github.com/Forneck/vitalia-reborn/security/code-scanning/3](https://github.com/Forneck/vitalia-reborn/security/code-scanning/3)

In general, to fix a "call to alloca in a loop" problem, you either (1) move the `alloca` call outside the loop and reuse the allocated buffer, or (2) replace `alloca` with a heap allocation (`malloc`/`free`) inside the loop. Here, the buffer size depends on `VariableNameTable[i].Max`, which is indexed by the loop variable, so we cannot move a single `alloca` outside the loop without over-allocating or complicating the code. The simplest, behavior-preserving fix is to replace the `alloca` call on line 2419 with `malloc`, check for allocation failure, and `free` the buffer before the loop body iteration ends.

Concretely, in `src/protocol.c` inside the `for (i = eMSDP_NONE + 1; i < eMSDP_MAX; ++i)` loop, locate the block:

```c
char *pBuffer = alloca(VariableNameTable[i].Max + 1);
int j; /* Loop counter */

for (j = 0; j < VariableNameTable[i].Max && *apValue != '\0'; ++apValue) {
    if (isprint(*apValue))
        pBuffer[j++] = *apValue;
}
pBuffer[j++] = '\0';

if (j >= VariableNameTable[i].Min) {
    free(apDescriptor->pProtocol->pVariables[i]->pValueString);
    apDescriptor->pProtocol->pVariables[i]->pValueString = AllocString(pBuffer);
}
```

Change it to allocate `pBuffer` with `malloc`, guard against `NULL`, and free it after use:

- Replace `alloca(VariableNameTable[i].Max + 1)` with `malloc(VariableNameTable[i].Max + 1)`.
- Add a `NULL` check: if allocation fails, skip updating the variable and break or `continue` the loop; here we’ll `continue` after an early `free` or without further use.
- Insert `free(pBuffer);` after the code that uses `pBuffer` (i.e., after the `if (j >= ...)` block) but before leaving that `if (VariableNameTable[i].bString)` branch.

No new headers are required: `<stdlib.h>` is typically already included via existing headers in this codebase, but since we are constrained to only edit the shown snippet in `src/protocol.c`, we will not modify includes. The existing `free` call on `pValueString` shows that the environment already uses standard allocation functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
