### PR TITLE
Potential fix for code scanning alert no. 63: Potential use after free

### DIFF
--- a/src/tedit.c
+++ b/src/tedit.c
@@ -134,6 +134,7 @@ ACMD(do_tedit)
     if (ch->desc->olc) {
         mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_tedit: Jogador já está editando.");
         free(ch->desc->olc);
+        ch->desc->olc = NULL;
     }
     CREATE(ch->desc->olc, struct oasis_olc_data, 1);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Forneck/vitalia-reborn/security/code-scanning/63](https://github.com/Forneck/vitalia-reborn/security/code-scanning/63)

In general, to fix a potential use-after-free involving a per-descriptor OLC structure, you must avoid dereferencing the old, freed `olc` pointer. That means either reusing the existing structure without freeing it, or if you do free it, allocating a new instance and assigning it back to the descriptor before any macro or function that expects a valid `olc` pointer is used. Additionally, after `free`, setting the pointer to `NULL` helps avoid accidental reuse.

The best minimal fix here, without changing user-visible behavior, is to (1) set `ch->desc->olc` to `NULL` immediately after `free(ch->desc->olc)` to prevent stale pointer reuse elsewhere, and (2) leave the existing `CREATE(ch->desc->olc, struct oasis_olc_data, 1);` line in place to allocate a new OLC data structure before `OLC_STORAGE(ch->desc)` is used on line 145. This ensures that any expansion of `OLC_STORAGE(d)` that depends on `d->olc` now operates on freshly allocated memory, not on the freed block. The only code change needed in the shown snippet is to extend the `if (ch->desc->olc)` block to null the pointer after freeing it; the allocation and subsequent use of `OLC_STORAGE` can remain as-is, since they already occur after the free.

Concretely, in `src/tedit.c`, within `ACMD(do_tedit)`, modify the block at lines 134–137 so that after logging and freeing `ch->desc->olc`, you also assign `ch->desc->olc = NULL;`. No new imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
