### PR TITLE
Potential fix for code scanning alert no. 60: Potential use after free

### DIFF
--- a/src/dg_triggers.c
+++ b/src/dg_triggers.c
@@ -266,7 +266,9 @@ void entry_memory_mtrigger(char_data *ch)
 
     for (actor = world[IN_ROOM(ch)].people; actor && SCRIPT_MEM(ch); actor = actor->next_in_room) {
         if (actor != ch && SCRIPT_MEM(ch)) {
-            for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); mem = mem->next) {
+            for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); ) {
+                struct script_memory *next_mem = mem->next;
+
                 if (char_script_id(actor) == mem->id) {
                     struct script_memory *prev;
                     if (mem->cmd)
@@ -293,6 +295,8 @@ void entry_memory_mtrigger(char_data *ch)
                         free(mem->cmd);
                     free(mem);
                 }
+
+                mem = next_mem;
             } /* for (mem =..... */
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Forneck/vitalia-reborn/security/code-scanning/60](https://github.com/Forneck/vitalia-reborn/security/code-scanning/60)

In general, to fix a use-after-free in a loop that iterates a linked list, you must save the “next” pointer in a temporary variable *before* you free the current node, and then advance the loop using that saved pointer instead of dereferencing the freed node. Alternatively, you can restructure the loop into a `while` that manually updates the current pointer after any potential deletion.

For this specific function in `src/dg_triggers.c`, the best minimal-change fix is:
- Change the `for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); mem = mem->next)` loop into a `for` that does not automatically advance `mem`.
- Introduce a `struct script_memory *next_mem;` variable inside the inner loop.
- At the start of the inner loop iteration (after confirming `mem` is non-NULL), set `next_mem = mem->next`.
- Perform all existing logic, including optionally freeing `mem`.
- At the end of the iteration, set `mem = next_mem` instead of relying on `mem = mem->next` in the `for` header.
This preserves behavior while ensuring we never read `mem->next` after `mem` is freed.

Concretely:
- Edit the loop header on line 269 to `for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); )` (remove the increment part).
- Inside that loop, declare `struct script_memory *next_mem = mem->next;` before any operation that might free `mem`.
- At the bottom of the inner `for (mem = ...)` body, after the `if (char_script_id(actor) == mem->id) { ... }` block, assign `mem = next_mem;`.
- The unlinking logic that adjusts `SCRIPT_MEM(ch)` and `prev->next` stays as is, but will now use the previously stored `next_mem` when continuing.

No new helper functions or external libraries are needed; only pointer handling inside this function is adjusted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
