### PR TITLE
Potential fix for code scanning alert no. 57: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/shop.c
+++ b/src/shop.c
@@ -1296,8 +1296,9 @@ static int end_read_list(struct shop_buy_data *list, int len, int error)
 static void read_line(FILE *shop_f, const char *string, void *data)
 {
     char buf[READ_SIZE];
+    int items_read;
 
-    if (!get_line(shop_f, buf) || !sscanf(buf, string, data)) {
+    if (!get_line(shop_f, buf) || (items_read = sscanf(buf, string, data)) != 1) {
         log1("SYSERR: Error in shop #%d, near '%s' with '%s'", SHOP_NUM(top_shop), buf, string);
         exit(1);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Forneck/vitalia-reborn/security/code-scanning/57](https://github.com/Forneck/vitalia-reborn/security/code-scanning/57)

General fix: for scanf-like calls, compare the return value to the number of expected successful conversions (here, 1), rather than only checking non-zero. This distinguishes “exactly what we expected” from “partial/none/EOF,” and optionally allows you to treat `EOF` differently if desired.

Best fix here, without changing existing functionality: in `read_line` (around line 1296–1304), change the condition that currently reads:

```c
if (!get_line(shop_f, buf) || !sscanf(buf, string, data)) {
```

to explicitly check that `sscanf` returns `1`:

```c
int items_read;
if (!get_line(shop_f, buf) || (items_read = sscanf(buf, string, data)) != 1) {
```

This preserves the current semantics: any case where `sscanf` does not read exactly one item (including `0` and `EOF`) continues to be treated as a fatal error. It also makes the code clearer in terms of expectations and satisfies the CodeQL rule. No new headers or external dependencies are needed; `sscanf` is already in use.

Concretely:

- Edit `src/shop.c` in the `static void read_line(FILE *shop_f, const char *string, void *data)` function.
- Introduce a local `int items_read;`.
- Replace the `if (!get_line(...) || !sscanf(...))` condition with one that assigns and checks `items_read != 1`.
- Keep the logging and `exit(1);` block unchanged so behavior remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
