### PR TITLE
Potential fix for code scanning alert no. 6: Redundant null check due to previous dereference

### DIFF
--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -293,7 +293,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig, int typ
             if (!str_cmp(vd->name, var) && (vd->context == 0 || vd->context == sc->context))
                 break;
 
-    if (!*field) {
+    if (!field || !*field) {
         if (vd)
             snprintf(str, slen, "%s", vd->value);
         else {
@@ -498,7 +498,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig, int typ
             }
             /* Addition inspired by Jamie Nelson. */
             else if (!str_cmp(var, "findobj")) {
-                if (!field || !*field || !subfield || !*subfield) {
+                if (!*field || !subfield || !*subfield) {
                     script_log("findobj.vnum(ovnum) - illegal syntax");
                     strcpy(str, "0");
                 } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Forneck/vitalia-reborn/security/code-scanning/6](https://github.com/Forneck/vitalia-reborn/security/code-scanning/6)

In general, this issue should be fixed by ensuring that any pointer being dereferenced is first checked for NULL, and by removing or tightening any later null-checks that are inconsistent with that behavior. Here, we already have a later check `if (!field || !*field || !subfield || !*subfield)` at line 501, so the intent seems to be that `field` may legitimately be NULL. That means the dereference at line 296 (`if (!*field)`) must also be guarded against a NULL `field` to prevent a null-pointer dereference. Once we add that guard, the `!field` part in the later condition becomes redundant because control flow would already avoid dereferencing `field` when it is NULL.

The best targeted fix is:
- At line 296, change `if (!*field) {` to `if (!field || !*field) {`, matching the defensive pattern used later and preventing dereference of a NULL `field`.
- At line 501, remove the redundant `!field ||` from the condition, since after the earlier guarded dereference, any path that reaches line 501 with `field == NULL` will already have been handled by the earlier `if (!field || !*field)` block. Thus we can safely simplify to `if (!*field || !subfield || !*subfield) {` without changing behavior.

These edits are confined to `src/dg_variables.c` within the lines shown and do not require new functions, imports, or type changes—just condition adjustments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
